### PR TITLE
#154953797 Enable social logins - Twitter

### DIFF
--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -16,6 +16,7 @@
 </form>
 <br>
 <a class="btn" style="background:#3B5998; color: white; margin-left: 195px;" href="{% url 'social:begin' 'facebook' %}?next={{ request.GET.next }}"><span class="fa fa-facebook"></span> Sign in with Facebook</a>
+<a class="btn" style="background:#55ACEE; color: white;" href="{% url 'social:begin' 'twitter' %}?next={{ request.GET.next }}"><span class="fa fa-twitter"></span> Sign in with Twitter</a>
 {% endblock %}
 
 

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -136,6 +136,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'wger.utils.helpers.EmailAuthBackend',
     'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.twitter.TwitterOAuth',
 )
 
 TEMPLATES = [
@@ -322,6 +323,9 @@ STATIC_URL = '/static/'
 
 SOCIAL_AUTH_FACEBOOK_KEY = '197453420843149'
 SOCIAL_AUTH_FACEBOOK_SECRET = 'a4fcf058e205ee880313053339ce3924'
+
+SOCIAL_AUTH_TWITTER_KEY = 'ljh2d8LqAR5UiSqQaxMzrWdyj'
+SOCIAL_AUTH_TWITTER_SECRET = 'WUoApa3arkk8rT5PmzKq3udliAfM6D6KZUSqNwCwCW7vGGqz4Y'
 
 
 # The default is not DEBUG, override if needed


### PR DESCRIPTION
#### What does this PR do?
Enable users to sign in/login with twitter.
#### Description of Task to be completed?
Currently, a new user cannot login with their pre-existing social media account. This task allows a user to login with their pre-existing social media accounts.
#### How should this be manually tested?
Go to the login page and select `sign in with twitter` button. This will redirect you and will ask you to login to your twitter account if you are not already logged in. Otherwise, it will log you in. Enjoy!
#### Any background context you want to provide?
The user could not log in using Twitter or any other pre-existing social media accounts.
#### What are the relevant pivotal tracker stories?
[154953797](https://www.pivotaltracker.com/story/show/154953797)
#### Screenshots (if appropriate)
* Login page
<img width="778" alt="screen shot 2018-02-14 at 11 10 17" src="https://user-images.githubusercontent.com/15800486/36194039-43d41e5a-1179-11e8-8cf2-809a5801e2d5.png">

* Authorize app and Login if not logged in.
<img width="771" alt="screen shot 2018-02-14 at 11 49 31" src="https://user-images.githubusercontent.com/15800486/36195142-963980f0-117d-11e8-84c9-2ce445f37e67.png">

* Authorize app if already login
<img width="706" alt="screen shot 2018-02-14 at 11 51 01" src="https://user-images.githubusercontent.com/15800486/36195180-b418c810-117d-11e8-91fe-703ab903ee78.png">

* Redirecting
<img width="761" alt="screen shot 2018-02-14 at 11 51 42" src="https://user-images.githubusercontent.com/15800486/36195602-1290e110-117f-11e8-9779-42c7570c7185.png">

* Logged In with Twitter account
<img width="1244" alt="screen shot 2018-02-14 at 12 04 24" src="https://user-images.githubusercontent.com/15800486/36195730-83034a5a-117f-11e8-863b-214312fcb9a5.png">


