### PR TITLE
#154953797 Enable social logins - Google

### DIFF
--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -15,8 +15,10 @@
     {% render_form_fields form submit_text %}
 </form>
 <br>
-<a class="btn" style="background:#3B5998; color: white; margin-left: 195px;" href="{% url 'social:begin' 'facebook' %}?next={{ request.GET.next }}"><span class="fa fa-facebook"></span> Sign in with Facebook</a>
-<a class="btn" style="background:#55ACEE; color: white;" href="{% url 'social:begin' 'twitter' %}?next={{ request.GET.next }}"><span class="fa fa-twitter"></span> Sign in with Twitter</a>
+<a class="btn" style="background:#3B5998; color: white; margin-left: 195px; width:24.2%" href="{% url 'social:begin' 'facebook' %}?next={{ request.GET.next }}"><span class="fa fa-facebook"></span> Sign in with Facebook</a>
+<a class="btn" style="background:#55ACEE; color: white; width:24.2%;" href="{% url 'social:begin' 'twitter' %}?next={{ request.GET.next }}"><span class="fa fa-twitter"></span> Sign in with Twitter</a>
+<a class="btn" style="background:#DD4B39; color: white; width:24.2%;" href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.GET.next }}"><span class="fa fa-google"></span> Sign in with Google</a>
+
 {% endblock %}
 
 

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -137,6 +137,9 @@ AUTHENTICATION_BACKENDS = (
     'wger.utils.helpers.EmailAuthBackend',
     'social_core.backends.facebook.FacebookOAuth2',
     'social_core.backends.twitter.TwitterOAuth',
+    'social_core.backends.open_id.OpenIdAuth',
+    'social_core.backends.google.GoogleOpenId',
+    'social_core.backends.google.GoogleOAuth2',
 )
 
 TEMPLATES = [
@@ -326,6 +329,9 @@ SOCIAL_AUTH_FACEBOOK_SECRET = 'a4fcf058e205ee880313053339ce3924'
 
 SOCIAL_AUTH_TWITTER_KEY = 'ljh2d8LqAR5UiSqQaxMzrWdyj'
 SOCIAL_AUTH_TWITTER_SECRET = 'WUoApa3arkk8rT5PmzKq3udliAfM6D6KZUSqNwCwCW7vGGqz4Y'
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "623986392163-qv6tes1ul1c1og7fu0l"\
+                                "424omfntslgku.apps.googleusercontent.com"
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'dcW3wprD5cMgzVB06VHzKi_d'
 
 
 # The default is not DEBUG, override if needed


### PR DESCRIPTION
#### What does this PR do?
- Enable users to sign in/login with Google.

#### Description of Task to be completed?
- Currently, a new user cannot login with their pre-existing social media account. This task allows a user to login with their pre-existing social media accounts.

#### How should this be manually tested?
- Go to the login page and select the sign in with google button. This will redirect you and will ask you to login to your google account if you are not already logged in.

#### What are the relevant pivotal tracker stories?
[154953797](https://www.pivotaltracker.com/story/show/154953797)

#### Screenshots (if appropriate)
<img width="1276" alt="screen shot 2018-02-14 at 20 39 39" src="https://user-images.githubusercontent.com/27849036/36219035-3864875a-11c7-11e8-8fc5-2d486e8b5787.png">

* Login page with all sign in buttons.
<img width="798" alt="screen shot 2018-02-15 at 17 57 43" src="https://user-images.githubusercontent.com/15800486/36262894-c6d29ba0-1279-11e8-9351-8611b11a11e1.png">


<img width="1114" alt="screen shot 2018-02-14 at 20 40 18" src="https://user-images.githubusercontent.com/27849036/36219078-5504d180-11c7-11e8-92f5-08cfa3785a00.png">

