### PR TITLE
#154953779 Cache nutritional values for plan

### DIFF
--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -117,56 +119,60 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {
-            'total': {
-                'energy': 0,
-                'protein': 0,
-                'carbohydrates': 0,
-                'carbohydrates_sugar': 0,
-                'fat': 0,
-                'fat_saturated': 0,
-                'fibres': 0,
-                'sodium': 0
-            },
-            'percent': {
-                'protein': 0,
-                'carbohydrates': 0,
-                'fat': 0
-            },
-            'per_kg': {
-                'protein': 0,
-                'carbohydrates': 0,
-                'fat': 0
-            },
-        }
+        result = cache.get(cache_mapper.get_nutritional_plan_key(self.id))
+        if not result:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {
+                'total': {
+                    'energy': 0,
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'carbohydrates_sugar': 0,
+                    'fat': 0,
+                    'fat_saturated': 0,
+                    'fibres': 0,
+                    'sodium': 0
+                },
+                'percent': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                },
+                'per_kg': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                },
+            }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][
-                    key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][
+                        key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            cache.set(cache_mapper.get_nutritional_plan_key(self.id), result)
+            cache.close()
 
         return result
 
@@ -725,3 +731,19 @@ class MealItem(models.Model):
                 nutritional_info[i]).quantize(TWOPLACES)
 
         return nutritional_info
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=MealItem)
+def delete_cache_data_on_change(sender, **kwargs):
+    """ Delete cache when signals are received"""
+    signal_instance = kwargs['instance']
+    if isinstance(signal_instance, (Meal, MealItem)):
+        cache.delete(cache_mapper.get_nutritional_plan_key(signal_instance.get_owner_object().id))
+
+    if isinstance(signal_instance, (NutritionPlan)):
+        cache.delete(cache_mapper.get_nutritional_plan_key(signal_instance.id))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -66,6 +66,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITIONAL_PLAN_CACHE_KEY = 'nutrition-info-{0}'
 
     def get_pk(self, param):
         '''
@@ -113,6 +114,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutritional_plan_key(self, param):
+        '''
+        Return nutrional plan cache key
+        '''
+        return self.NUTRITIONAL_PLAN_CACHE_KEY.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?
- Cache the nutritional_info dictionary in NutritionPlans
- Add signals that delete the cache key every time a NutritionPlan, Meal and MealItem is added, edited or deleted.

#### Description of Task to be completed?
- If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[154953779](https://www.pivotaltracker.com/story/show/154953779)

#### Screenshots (if appropriate)
- Without cache
<img width="1246" alt="screen shot 2018-02-20 at 14 26 20" src="https://user-images.githubusercontent.com/27849036/36428624-77f076ec-1661-11e8-8e95-92775180ae58.png">

- With cache
<img width="1245" alt="screen shot 2018-02-20 at 14 25 46" src="https://user-images.githubusercontent.com/27849036/36428666-969d9f34-1661-11e8-98d7-b2e07ac4b5fc.png">

