### PR TITLE
 #154953795 managers delete and deactivate gym trainers 

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -27,8 +27,10 @@
 <thead>
 <tr>
     <th style="width: 10%;">{% trans "ID" %}</th>
-    <th style="width: 40%;">{% trans "Username" %}</th>
-    <th>{% trans "Name" %}</th>
+    <th style="width: 20%;">{% trans "Username" %}</th>
+    <th >{% trans "Name" %}</th>
+    <th>{% trans "Active" %}</th>
+    <th>{% trans "Action" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         <th style="text-align: right;">{% trans "Roles" %}</th>
     {% endif %}
@@ -41,7 +43,9 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
@@ -55,11 +59,26 @@
             <span class="label label-primary">{% trans "General manager" %}</span>
         {% endif %}
     </td>
+    
     <td>
-        {{current_user.obj.get_full_name}}
+        {% if current_user.obj.is_active %}
+        <span>Yes</span>
+        {% else %}
+        <span>No</span>
+        {% endif %}
     </td>
 
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+    <td>
+    {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+    {% if current_user.obj.is_active %}
+    <a href="{% url 'core:user:deactivate' current_user.obj.pk %}" style="color:#f0ad4e">Deactivate</a>
+    {% else %}
+    <a href="{% url 'core:user:activate' current_user.obj.pk %}" style="color:#5cb85c">Activate</a>
+    {% endif %}
+    {% endif %}
+</td>
+
     <td style="text-align: right;">
         <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
             <span class="{% fa_class 'cog' %}"></span>


### PR DESCRIPTION
#### What does this PR do?
Allow managers to delete or deactivate trainers from a gym

#### Description of Task to be completed?
Currently a manager cannot delete or deactivate trainers rom a gym.
They should be able to do this

#### How should this be manually tested?
First login as admin, create a gym and add a member as a gym administrator or general manager, when the managers login they are able to add trainers, deactivate, activate and delete them with in the gym.

#### Any background context you want to provide?
Only the administrator was able to deactivate and delete trainers.

#### What are the relevant pivotal tracker stories?
[154953795](https://www.pivotaltracker.com/story/show/154953795)

#### Screenshots (if appropriate)
When he is a gym manager
<img width="1439" alt="screen shot 2018-02-21 at 12 03 53" src="https://user-images.githubusercontent.com/30952856/36471767-b87c70ae-1700-11e8-9fbc-7d9ea63ebe90.png">
when he is a general manager
<img width="1436" alt="screen shot 2018-02-21 at 12 05 13" src="https://user-images.githubusercontent.com/30952856/36471801-d3b94054-1700-11e8-8bc2-4b33149ffa01.png">
