### PR TITLE
#154953787 Allow members comparison

### DIFF
--- a/wger/core/templates/comparison.html
+++ b/wger/core/templates/comparison.html
@@ -1,0 +1,88 @@
+{% extends "base_wide.html" %} {% load i18n staticfiles wger_extras %} {% block title %}{% trans "Weight Comparison" %}{% endblock%}
+{% block header %}
+<script src="{% static 'js/user.js' %}"></script> 
+{% endblock %} {% block content %}
+
+<div id="current-username" data-current-username="{{ owner_user.username }}" value="{{ owner_user.username }}"></div>
+
+<div class="row">
+
+    <div class="col-md-6">
+        My Graph
+        {% if not min_date %}
+        <p>
+            {% trans "There is no chart here because there are no weight entries." %}
+        </p>
+        {% endif %}
+        <div id="user_diagram"></div>
+    </div>
+
+    <div class="col-md-6">
+        <select id="user-change" onchange="userchange(this.value)">
+            <option value="{{ owner_user.username }}">{{ owner_user.username }}</option>
+            {% for user in users %}
+            <option value="{{user}}">{{ user }} </option>
+            {% endfor %}
+        </select>
+        <p id="nope">There is no chart here because there are no weight entries.</p>
+        <div id="others_diagram"></div>
+        
+       
+
+    </div>
+</div>
+<script>
+  function userchange(username) {
+  var url;
+  var chartParams;
+  var weightChart;
+  weightChart = {};
+  chartParams = {
+    animate_on_load: true,
+    full_width: true,
+    top: 10,
+    left: 30,
+    right: 10,
+    show_secondary_x_label: true,
+    xax_count: 10,
+    target: '#others_diagram',
+    x_accessor: 'date',
+    y_accessor: 'weight',
+    min_y_from_data: true,
+    colors: ['#3465a4']
+  };
+
+  url = '/weight/api/get_user_weight_data/' + username;
+
+  d3.json(url, function (json) {
+    var data;
+    if (json.length) {
+      $('#others_diagram').show();
+      data = MG.convert.date(json, 'date');
+      weightChart.data = data;
+
+      // Plot the data
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+      $('#nope').hide();
+    } else {
+      $('#nope').show();
+      $('#others_diagram').hide();
+    }
+  });
+
+  $('.modify-time-period-controls button').click(function () {
+    var pastNumberDays = $(this).data('time_period');
+    var data = modifyTimePeriod(weightChart.data, pastNumberDays);
+
+    // change button state
+    $(this).addClass('active').siblings().removeClass('active');
+    if (data.length) {
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+}
+
+</script>
+{% endblock %}

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -200,6 +200,16 @@
                                     <li>
                                         <a href="{% url 'core:user:preferences' %}">{% trans "My preferences" %}</a>
                                     </li>
+                                    <li {% if active_tab == 'user' %}class="active"{% endif %}>
+                                        <a href="{% url 'core:comparison' %}">
+                                            {% if not user.is_authenticated %}
+                                                {% trans "Features" %}
+                                            {% else %}
+                                                {% trans "Comparisons" %}
+                                            {% endif %}
+                                        </a>
+                                    </li>
+
                                     {% if not trainer_identity %}
                                     <li class="divider"></li>
                                     <li>

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -141,6 +141,9 @@ urlpatterns = [
     # The dashboard
     url(r'^dashboard$', misc.dashboard, name='dashboard'),
 
+    # The comparisons page
+    url(r'^comparison$', misc.comparison, name='comparison'),
+
     # Others
     url(r'^about$',
         TemplateView.as_view(template_name="misc/about.html"),

--- a/wger/core/views/misc.py
+++ b/wger/core/views/misc.py
@@ -29,6 +29,9 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login as django_login
 from django.template.loader import render_to_string
+from django.contrib.auth.models import User
+from django.db.models import Min
+from django.db.models import Max
 
 from wger.core.forms import FeedbackRegisteredForm, FeedbackAnonymousForm
 from wger.core.demo import create_demo_entries, create_temporary_user
@@ -37,6 +40,8 @@ from wger.manager.models import Schedule
 from wger.nutrition.models import NutritionPlan
 from wger.weight.models import WeightEntry
 from wger.weight.helpers import get_last_entries
+from wger.weight import helpers
+from wger.utils.helpers import check_access
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +85,48 @@ def demo_entries(request):
               'better see what  this site can do. Feel free to edit or '
               'delete them!'))
     return HttpResponseRedirect(reverse('core:dashboard'))
+
+
+def comparison(request, username=None):
+    '''
+    Analysis page
+    '''
+    users = list(User.objects.all())
+
+    ctx = {
+        "users": users,
+    }
+    is_owner, user = check_access(request.user, username)
+
+    template_data = {}
+
+    min_date = WeightEntry.objects.filter(user=user).\
+        aggregate(Min('date'))['date__min']
+    max_date = WeightEntry.objects.filter(user=user).\
+        aggregate(Max('date'))['date__max']
+    if min_date:
+        template_data['min_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' % \
+                                    {'year': min_date.year,
+                                     'month': min_date.month,
+                                     'day': min_date.day}
+    if max_date:
+        template_data['max_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' % \
+                                    {'year': max_date.year,
+                                     'month': max_date.month,
+                                     'day': max_date.day}
+
+    last_weight_entries = helpers.get_last_entries(user)
+
+    template_data['users'] = users
+    template_data['is_owner'] = is_owner
+    template_data['owner_user'] = user
+    template_data['show_shariff'] = is_owner
+    template_data['last_five_weight_entries_details'] = last_weight_entries
+
+    if request.user.is_authenticated():
+        return render(request, 'comparison.html', template_data)
+    else:
+        return render(request, 'index.html')
 
 
 @login_required

--- a/wger/utils/month_range.py
+++ b/wger/utils/month_range.py
@@ -1,0 +1,10 @@
+from datetime import datetime, date, timedelta
+import calendar
+
+
+def get_month_range(start_date=None):
+    if start_date is None:
+        start_date = date.today().replace(day=1)
+    _, days_in_month = calendar.monthrange(start_date.year, start_date.month)
+    end_date = start_date + timedelta(days=days_in_month)
+    return (start_date, end_date)

--- a/wger/weight/static/js/user.js
+++ b/wger/weight/static/js/user.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
     right: 10,
     show_secondary_x_label: true,
     xax_count: 10,
-    target: '#weight_diagram',
+    target: '#user_diagram',
     x_accessor: 'date',
     y_accessor: 'weight',
     min_y_from_data: true,
@@ -53,7 +53,7 @@ $(document).ready(function () {
   };
 
   username = $('#current-username').data('currentUsername');
-  url = '/weight/api/get_weight_data/' + username;
+  url = '/weight/api/get_logged_user_weight_data/' + username;
 
   d3.json(url, function (json) {
     var data;

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -43,4 +43,12 @@ urlpatterns = [
         r'^api/get_weight_data/$',  # JS
         views.get_weight_data,
         name='weight-data'),
+    url(
+    r'^api/get_user_weight_data/(?P<username>[\w.@+-]+)$',  # JS
+    views.get_user_weight_data,
+    name='user-weight-data'),
+    url(
+    r'^api/get_logged_user_weight_data/(?P<username>[\w.@+-]+)$',  # JS
+    views.get_logged_user_weight_data,
+    name='logged_user-weight-data'),
 ]

--- a/wger/weight/views.py
+++ b/wger/weight/views.py
@@ -30,6 +30,7 @@ from django.db.models import Min
 from django.db.models import Max
 from django.views.generic import CreateView
 from django.views.generic import UpdateView
+from django.contrib.auth.models import User
 
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
@@ -39,6 +40,7 @@ from formtools.preview import FormPreview
 from wger.weight.forms import WeightForm
 from wger.weight.models import WeightEntry
 from wger.weight import helpers
+from wger.utils.month_range import get_month_range
 from wger.utils.helpers import check_access
 from wger.utils.generic_views import WgerFormMixin
 
@@ -177,6 +179,49 @@ def get_weight_data(request, username=None):
             user=user, date__range=(date_min, date_max))
     else:
         weights = WeightEntry.objects.filter(user=user)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+
+@api_view(['GET'])
+def get_logged_user_weight_data(request, username=None):
+    '''
+    Process the data to pass it to the JS libraries to generate an SVG image
+    '''
+
+    is_owner, user = check_access(request.user, username)
+
+    date_min_max = get_month_range()
+
+    if date_min_max:
+        weights = WeightEntry.objects.filter(
+            user=user, date__range=date_min_max)
+    else:
+        weights = WeightEntry.objects.filter(user=user)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+
+@api_view(['GET'])
+def get_user_weight_data(request, username=None):
+    '''
+    Process the data to pass it to the JS libraries to generate an SVG image
+    '''
+    user = User.objects.filter(username=username)
+    date_min_max = get_month_range()
+    weights = WeightEntry.objects.filter(user=user, date__range=date_min_max)
 
     chart_data = []
 


### PR DESCRIPTION
#### What does this PR do?
- This PR enables for comparison of members

#### Description of Task to be completed?
- When two users are training together it would be useful to see a comparison of some sorts. A possibility would be to have a graph where the data for (selected) members is shown or, less nicely, at least have different graphs under each other.

#### How should this be manually tested?
- On the main menu click on the item on the far right of the screen, on the drop down select comparisons. On this page you should view a graph showing your weights over the current month, you can as well compare yourself with a member by selecting a name from the options beside the graph.

#### What are the relevant pivotal tracker stories?
- [154953787](https://www.pivotaltracker.com/story/show/154953787)

#### Screenshots (if appropriate)
<img width="1403" alt="screen shot 2018-02-21 at 15 24 41" src="https://user-images.githubusercontent.com/27849036/36479981-b1fa73dc-171b-11e8-8d8d-7a5e01e1ad96.png">
