### PR TITLE
#155498700 Ensure only members in same gym are compared

### DIFF
--- a/wger/core/templates/comparison.html
+++ b/wger/core/templates/comparison.html
@@ -20,9 +20,13 @@
     <div class="col-md-6">
         <select id="user-change" onchange="userchange(this.value)">
             <option value="none">--------</option>
+            {% if others %}
             {% for user in others %}
             <option value="{{user}}">{{ user }} </option>
             {% endfor %}
+            {%else%}
+            NO user to compare with
+            {% endif%}
         </select>
         <p id="nope">There is no chart here because there are no weight entries.</p>
         <div id="others_diagram"></div>

--- a/wger/core/views/misc.py
+++ b/wger/core/views/misc.py
@@ -99,6 +99,17 @@ def comparison(request, username=None):
     is_owner, user = check_access(request.user, username)
     others = User.objects.exclude(username=user.username)
 
+    users_with_same_gym = []
+
+    for _user in others:
+
+        try:
+
+            if _user.userprofile.gym.id == request.user.userprofile.gym.id:
+                users_with_same_gym.append(_user)
+        except Exception:
+            pass
+
     template_data = {}
 
     min_date = WeightEntry.objects.filter(user=user).\
@@ -119,7 +130,7 @@ def comparison(request, username=None):
     last_weight_entries = helpers.get_last_entries(user)
 
     template_data['users'] = users
-    template_data['others'] = others
+    template_data['others'] = users_with_same_gym
     template_data['is_owner'] = is_owner
     template_data['owner_user'] = user
     template_data['show_shariff'] = is_owner


### PR DESCRIPTION
#### What does this PR do?
- This PR enables for comparison of members in the same gym.

#### Description of Task to be completed?
- When a comparison is being made, only users in the same gym as the user logged in should be available for selection.

#### How should this be manually tested?
- On the main menu click on the item on the far right of the screen, on the drop down select comparisons. On this page you should view a graph showing your weights over the current month, you can as well compare yourself with a member in your gym by selecting a name from the options beside the graph.

#### What are the relevant pivotal tracker stories?
[155498700](https://www.pivotaltracker.com/story/show/155498700)

#### Screenshots (if appropriate)
- Members in a gym
<img width="1389" alt="screen shot 2018-02-25 at 23 04 58" src="https://user-images.githubusercontent.com/27849036/36645887-5f1c7d96-1a80-11e8-9830-0348bff91fc1.png">

- Graph dropdown
<img width="1332" alt="screen shot 2018-02-25 at 23 06 48" src="https://user-images.githubusercontent.com/27849036/36645895-99371ebe-1a80-11e8-85cc-defca728b467.png">



#### Questions: