### PR TITLE
#155427117 Enable Administrator to change the roles of gym users

### DIFF
--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -358,7 +358,7 @@ def gym_permissions_user_edit(request, user_pk):
 
     if request.method == 'POST':
         form = GymUserPermisssionForm(
-            request.POST, available_roles=form_group_permission)
+            form_group_permission, request.POST)
 
         if form.is_valid():
 


### PR DESCRIPTION
#### What does this PR do?
Enable Administrator to change the roles of gym users

#### Description of Task to be completed?
Currently there is no permission to change roles by admin.
-That should be done.

#### How should this be manually tested?
Login as admin and create a gym with an admin, that gym admin once logged in he will be able to edit roles of gym users

#### Any background context you want to provide?
There were no permissions to edit the roles

#### What are the relevant pivotal tracker stories?
[155427117](https://www.pivotaltracker.com/story/show/155427117)
