### PR TITLE
 #154953785 Make translations easier

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,22 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+{% block title %}
+{% trans "Exercises" %}
+<div class="btn-group" style="float:right;">
+    <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Filter by language" %}  <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'exercise:exercise:overview' %}>None</li>
+        {% for sn, language in languages %}
+            <li><a href={% url 'exercise:exercise:overview' %}?lang={{ sn }}>{{ language }}
+            </li>
+        {% endfor %} 
+    </ul>
+</div>
+    
+{% endblock %}
 
 
 
@@ -43,7 +58,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -82,8 +82,8 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.name, "Another category")
 
         category_2 = response.context['exercises'][1].category
-        self.assertEqual(category_2.id, 3)
-        self.assertEqual(category_2.name, "Yet another category")
+        self.assertEqual(category_2.id, 2)
+        self.assertEqual(category_2.name, "Another category")
 
         # Correct exercises in the categories
         exercises_1 = category_1.exercise_set.all()

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,22 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}
+{% trans "Ingredient overview" %}
+<div class="btn-group" style="float:right;">
+        <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Filter by language" %}
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            {% for sn, language in languages %}
+            <li>
+                <a href={% url 'nutrition:ingredient:list' %}?lang={{ sn }}> {{ language }}</a>
+            </li>
+            {% endfor %} 
+        </ul>
+    </div>
+{% endblock %}
 
 
 {% block content %}

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -27,6 +27,7 @@ from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.generic import (DeleteView, CreateView, UpdateView, ListView)
 
 from wger.nutrition.forms import UnitChooserForm
+from wger.core.models import Language
 from wger.nutrition.models import Ingredient
 from wger.utils.generic_views import (WgerFormMixin, WgerDeleteMixin)
 from wger.utils.constants import PAGINATION_OBJECTS_PER_PAGE
@@ -55,9 +56,18 @@ class IngredientListView(ListView):
         (the user can also want to see ingredients in English, in addition to his
         native language, see load_ingredient_languages)
         '''
-        languages = load_ingredient_languages(self.request)
-        return (Ingredient.objects.filter(language__in=languages)
-                .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only(
+        query_language = self.request.GET.get('lang', None)
+        language = None
+        if query_language:
+            ln = Language.objects.filter(short_name=query_language)
+            if ln.exists():
+                language = ln.first().id
+        if language:
+            return (Ingredient.objects.filter(language=language)
+                    .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only(
+                        'id', 'name'))
+        return (Ingredient.objects.filter(
+                status__in=Ingredient.INGREDIENT_STATUS_OK).only(
                     'id', 'name'))
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
#### What does this PR do?
It allows a user to filter exercises and Ingredients by language so as to make it easier for them to view them in a specific language.
#### Description of Task to be completed?
Every ingredient and exercise has a field indicating the language, which is automatically set as the user's current language when adding them.
The current list is then filtered based on this.

The user should be able to select which languages to show. They should not be shown only their current language.
#### How should this be manually tested?
Navigate to either the exercises or Ingredients overview then use the filter by language button to get the ingredients/exercises in that specific language.
#### What are the relevant pivotal tracker stories?
[#154953785](https://www.pivotaltracker.com/story/show/154953785)
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-02-28 at 12 59 08" src="https://user-images.githubusercontent.com/9350722/36781544-383caab2-1c87-11e8-8de3-bc4a2827b3f8.png">

