### PR TITLE
 #154953784 Reset cache on muscle delete

### DIFF
--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -17,11 +17,21 @@
 from django.db.models.signals import pre_save
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from django.core.cache import cache
+
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
 
-from wger.exercises.models import ExerciseImage
+from wger.exercises.models import ExerciseImage, Muscle
+
+
+@receiver(post_delete, sender=Muscle)
+def reset_cache_on_muscle_delete(sender, instance, **kwargs):
+    '''
+    Clear the cache after muscle is deleted
+    '''
+    cache.clear()
 
 
 @receiver(post_delete, sender=ExerciseImage)


### PR DESCRIPTION
#### What does this PR do?
- Clears cache after a muscle is deleted

#### Description of Task to be completed?
When a muscle is deleted, it should not be visible within the exercise view.

#### How should this be manually tested?
- Once logged in as an admin you could create a new muscle from the view `http://localhost:8000/en/exercise/muscle/admin-overview/`
- Then create a new exercise which focuses on the new muscle
- Delete the new muscle then check that it is not included in the exercise

#### Any background context you want to provide?
After deleting a muscle, it keeps appearing in exercise descriptions etc. This is probably due to the cache not being correctly reset.

#### What are the relevant pivotal tracker stories?
[#154953784](https://www.pivotaltracker.com/story/show/154953784)
