### PR TITLE
#155848293 Add svg image for muscle

### DIFF
--- a/wger/core/static/images/muscles/main/muscle-16.svg
+++ b/wger/core/static/images/muscles/main/muscle-16.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="200"
+   height="369.03"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="muscle-16.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="10.244411"
+     inkscape:cy="223.52075"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="900"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Ebene 2"
+     style="display:inline;opacity:0.83">
+    <path
+       style="opacity:0.72424239;fill:#fc0000;fill-opacity:1;stroke:none"
+       d="m 96.2091,40.782352 c 0,0 -3.95345,14.204531 -4.9636,21.275599 1.07688,4.530341 4.30935,15.192636 4.30935,15.192636 L 96.09866,98.4454 c 0,0 -5.39366,19.55225 -0.49034,26.98269 0,0 -8.57148,52.39632 1.80134,53.59311 12.48222,1.44017 4.34311,-52.29705 4.34311,-52.29705 l 2.67537,-10.51305 -2.28637,-12.98143 c 0,0 -0.33332,-28.07589 3.37167,-33.741658 3.70499,-5.665769 -4.49729,-29.969552 -4.49729,-29.969552 z"
+       id="path288"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccscccscc" />
+  </g>
+</svg>

--- a/wger/core/static/images/muscles/secondary/muscle-16.svg
+++ b/wger/core/static/images/muscles/secondary/muscle-16.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="200"
+   height="369.03"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="muscle-16.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="50.650513"
+     inkscape:cy="223.52075"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="900"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Ebene 2"
+     style="display:inline;opacity:0.9">
+    <path
+       style="fill:#ff7f2a;stroke:#000000;stroke-width:0.99384868000000004px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 96.2091,40.782352 c 0,0 -3.95345,14.204531 -4.9636,21.275599 1.07688,4.530341 4.30935,15.192636 4.30935,15.192636 L 96.09866,98.4454 c 0,0 -5.39366,19.55225 -0.49034,26.98269 0,0 -8.57148,52.39632 1.80134,53.59311 12.48222,1.44017 4.34311,-52.29705 4.34311,-52.29705 l 2.67537,-10.51305 -2.28637,-12.98143 c 0,0 -0.33332,-28.07589 3.37167,-33.741658 3.70499,-5.665769 -4.49729,-29.969552 -4.49729,-29.969552 z"
+       id="path288"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccscccscc" />
+  </g>
+</svg>

--- a/wger/exercises/fixtures/exercises.json
+++ b/wger/exercises/fixtures/exercises.json
@@ -7783,6 +7783,50 @@
         "model": "exercises.exercise"
     },
     {
+        "pk": 396,
+        "fields": {
+            "license_author": "wger.de",
+            "status": "2",
+            "language": 2,
+            "muscles_secondary": [],
+            "description": "<p>Stand with your feet hip-distance apart, feet flat on the floor below the bar. Squat down and grasp the bar just outside your shins with an overhand or mixed grip (one overhand, one underhand). </p>\n<p>\u00a0</p>",
+            "equipment": [
+                10
+            ],
+            "creation_date": "2018-03-07",
+            "category": 12,
+            "uuid": "76964898-192c-4e93-b24c-914ea542002b",
+            "muscles": [
+                16
+            ],
+            "license": 2,
+            "name": "Deadlift"
+        },
+        "model": "exercises.exercise"
+    },
+    {
+        "pk": 397,
+        "fields": {
+            "license_author": "wger.de",
+            "status": "2",
+            "language": 2,
+            "muscles_secondary": [],
+            "description": "<p>Lie on an exercise mat on your stomach. Bring your legs together and extend your arms out past your head. Lift your torso and legs off the floor as high as you can. Pause at the top, then return to the starting position. </p>\n<p>\u00a0</p>",
+            "equipment": [
+                4
+            ],
+            "creation_date": "2018-03-07",
+            "category": 12,
+            "uuid": "76964898-192c-4e93-b24c-914ea542002b",
+            "muscles": [
+                16
+            ],
+            "license": 2,
+            "name": "Superman Exercise"
+        },
+        "model": "exercises.exercise"
+    },
+    {
         "pk": 6,
         "fields": {
             "exercise": 33,


### PR DESCRIPTION
#### What does this PR do?
- Add svg image for erector spinae muscle

#### Description of Task to be completed?
- Svg images could be added for the following muscle:
         Erector spinae

#### Any background context you want to provide?
- Erector spinae muscle had no svg image nor exercises before.

#### What are the relevant pivotal tracker stories?
- [155848293](https://www.pivotaltracker.com/story/show/155848293)

#### Screenshots (if appropriate)
- 
<img width="1369" alt="screen shot 2018-03-12 at 12 24 31" src="https://user-images.githubusercontent.com/27849036/37275486-6b929fee-25f0-11e8-9361-61afc3b6eb6f.png">


#### Questions: